### PR TITLE
update alias_method_chain references

### DIFF
--- a/lib/zuora/attributes.rb
+++ b/lib/zuora/attributes.rb
@@ -51,7 +51,8 @@ module Zuora
                 @#{scope} = #{scope}_without_complex
               end
             end
-            alias_method_chain :#{scope}, :complex
+            alias_method :#{scope}_without_complex, :#{scope}
+            alias_method :#{scope}, :#{scope}_with_complex
           EVAL
         end
       end


### PR DESCRIPTION
final changed required for flipping the switch on rails 5 (following https://github.com/backupify/zuora/pull/8)